### PR TITLE
Auto-close active sockets on termination.  Bumped to v0.7.2.

### DIFF
--- a/background.js
+++ b/background.js
@@ -21,22 +21,27 @@ chrome.app.runtime.onLaunched.addListener(function() {
         id: "BlocklyProp-Launcher",
         innerBounds: {
             width: 500,
-            height: 414,
-            maxWidth: 500,
-            maxHeight: 500,
-            minWidth: 200,
-            minHeight: 200
-        }, state: "normal"
+            height: 414
+        }, state: "normal",
+        resizable: false
     }, function(win) {
       win.onClosed.addListener(closeSerialPorts);
+      win.onClosed.addListener(closeServer);
     });
   });
 
-function closeSerialPorts(){
+function closeSerialPorts() {
 // Close this app's active serial ports
     chrome.serial.getConnections(function(activeConnections) {
         activeConnections.forEach(function(port) {
             chrome.serial.disconnect(port.connectionId, function() {});
         });
+    });
+}
+
+function closeServer() {
+// Close this app's active server(s)
+    chrome.sockets.tcpServer.getSockets(function (socketInfos) {
+        socketInfos.forEach(function(v) {chrome.sockets.tcpServer.close(v.socketId)});
     });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BlocklyProp Launcher",
   "description": "A Chrome application that connects your Propeller-Powered Hardware to the BlocklyProp website.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "manifest_version": 2,
   "minimum_chrome_version": "45",
   


### PR DESCRIPTION
Enhanced to close active socket server(s) upon application termination to prevent later sessions from establishing a server on same port.  

Made window fixed-size to prevent earlier session resizes from hiding updated graphics that happen to be larger.

Bumped to v0.7.2.