### PR TITLE
#74 Removed Websocket disconnect button

### DIFF
--- a/index.css
+++ b/index.css
@@ -70,8 +70,8 @@ body {
 }
 
 #log {
-  height: 255px;
-  width: 278px;
+  height: 278px;
+  width: 285px;
   overflow-y: scroll;
   background: #fff;
   border: 1px solid #ccc;
@@ -79,8 +79,8 @@ body {
 }
 
 #wx-list {
-  height: 255px;
-  width: 270px;
+  height: 259px;
+  width: 267px;
   overflow-y: scroll;
   background: #fff;
   border: 1px solid #ccc;

--- a/index.html
+++ b/index.html
@@ -23,12 +23,6 @@
       <table border="0" cellpadding="0" cellspacing="0" width="100%">
         <tr><td colspan="2" class="folder-page">
           <table border="0" cellpadding="1" cellspacing="0" id="port-path-settings" class='pane-table'>
-            <!--
-            <tr>
-              <td>Send:</td>
-              <td colspan="2"><input type="text" id="input" placeholder="Type a message to other connected clients here" style="width:200px;"></td>
-            </tr>
-            -->
             <tr>
               <td>Path/IP Address:</td>
               <td><input type="text" id="bpc-url" class="con" style="width:150px;"/></td>
@@ -37,10 +31,6 @@
             <tr>
               <td>Port:</td>
               <td><input type="text" id="bpc-port" class="con" style="width:150px;"/></td>
-            </tr>
-            <tr>
-              <td>Websocket:</td>
-              <td><button id="websocket-connect" disabled="true" style="width:155px;">Waiting...</button></td>
             </tr>
             <tr>
               <td>Verbose Logging:</td>

--- a/index.js
+++ b/index.js
@@ -126,14 +126,6 @@ document.addEventListener('DOMContentLoaded', function() {
     $('sm-3').value = '0';
   }
 
-  $('websocket-connect').onclick = function() {
-    if($('websocket-connect').innerHTML === 'Connect') {
-      connect();
-    } else {
-      disconnect();
-    }
-  };
-
   $('open-browser').onclick = function() {
     chrome.browser.openTab({ url: "https://blockly.parallax.com/"});
   };
@@ -146,7 +138,7 @@ document.addEventListener('DOMContentLoaded', function() {
       chrome.storage.sync.set({'s_port':$('bpc-port').value}, function() {});
       chrome.storage.sync.set({'s_url':$('bpc-url').value}, function() {});
     }
-    connect_ws($('bpc-port').value, $('bpc-url').value);
+    connect();
   };
 
   // TODO: re-write this to use onblur and/or onchange to auto-save. 
@@ -228,14 +220,10 @@ function updateStatus(connected) {
   if (connected) {
       $('connect-disconnect').innerHTML = '&#10004; Connected';
       $('connect-disconnect').className = 'status status-green';
-      $('websocket-connect').disabled = false;
-      $('websocket-connect').innerHTML = 'Disconnect';
       log('BlocklyProp site connected');
   } else {
       $('connect-disconnect').className = 'status status-clear';
       $('connect-disconnect').innerHTML = 'Waiting to<br>connect...<span class="statustiptext">To connect:<br>Open browser to BlocklyProp<br>site, then navigate to<br>View/Edit project code</span>';
-      $('websocket-connect').disabled = true;
-      $('websocket-connect').innerHTML = 'Waiting...';
       log('BlocklyProp site disconnected');
   }
 }


### PR DESCRIPTION
Removed Websocket disconnect/connect button from settings pane as well as all associated code.  This was a legacy debugging feature that was no longer necessary after autoconnect/autodisconnect was implemented.

- Resized all surrounding elements accordingly.
- Also replaced direct connect code with proper function call.