### PR TITLE
Add base64 encoding where it was missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,7 @@ function connect_ws(ws_port, url_path) {
                     setTimeout(function() {loadPropeller(socket, ws_msg.portPath, ws_msg.action, ws_msg.payload, ws_msg.debug)}, 10);  // success is a JSON that the browser generates and expects back to know if the load was successful or not
                 } else if (ws_msg.type === "serial-terminal") {
                     // open or close the serial port for terminal/debug
-                    serialTerminal(socket, ws_msg.action, ws_msg.portPath, ws_msg.baudrate, ws_msg.msg); // action is "open", "close" or "msg"
+                    serialTerminal(socket, ws_msg.action, ws_msg.portPath, ws_msg.baudrate, atob(ws_msg.msg)); // action is "open", "close" or "msg"
                 } else if (ws_msg.type === "port-list-request") {
                     // send an updated port list (and continue on scheduled interval)
 //                  log("Browser requested port-list for socket " + socket.pSocket_.socketId, mDbug);
@@ -455,7 +455,7 @@ function sendPortList(socket) {
 
 
 function helloClient(sock, baudrate) {
-    var msg_to_send = {type:'hello-client', version:clientVersion};
+    var msg_to_send = {type:'hello-client', version:clientVersion, rxBase64:true};
     sock.send(JSON.stringify(msg_to_send));
 }
 

--- a/index.js
+++ b/index.js
@@ -477,7 +477,7 @@ function serialTerminal(sock, action, portName, baudrate, msg) {
                 .then(function() {log('Connected terminal to ' + portName + ' at ' + baudrate + ' baud.');})
                 .catch(function() {
                     log('Unable to connect terminal to ' + portName);
-                    var msg_to_send = {type:'serial-terminal', msg:'Failed to connect.\rPlease close this terminal and select a connected port.'};
+                    var msg_to_send = {type:'serial-terminal', msg:btoa('Failed to connect to ' + portName + '.\rPlease close this terminal and select a connected port.')};
                     sock.send(JSON.stringify(msg_to_send));
                 });
         } else if (action === "close") {
@@ -492,7 +492,7 @@ function serialTerminal(sock, action, portName, baudrate, msg) {
             }
         }
     } else {
-        var msg_to_send = {type:'serial-terminal', msg:'Port ' + portName + ' not found.\rPlease close this terminal and select an existing port.'};
+        var msg_to_send = {type:'serial-terminal', msg:btoa('No device connected.\rPlease close this terminal and select an existing port.')};
         sock.send(JSON.stringify(msg_to_send));
     }
 }


### PR DESCRIPTION
These changes are safe to implement at any point after solo/200 is fully implemented.  There are flags in the browser and a try/catch set up to allow "No port" messages to be received whether they are encoded or not.