### PR TITLE
Mac release 5

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,7 +7,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
         id: "BlocklyProp-Launcher",
         innerBounds: {
             width: 500,
-            height: 414
+            height: 433
         }, state: "normal",
         resizable: false
     }, function(win) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BlocklyProp Launcher",
   "description": "A Chrome application that connects your Propeller-Powered Hardware to the BlocklyProp website.",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "manifest_version": 2,
   "minimum_chrome_version": "45",
   

--- a/package/mac-resources/welcome.html
+++ b/package/mac-resources/welcome.html
@@ -8,6 +8,6 @@
 
   <p>This software installs the BlocklyProp Launcher into your Applications folder.</p>
 
-  <p>Copyright (c) 2021 Parallax Inc.</p>
+  <p>Copyright (c) 2022 Parallax Inc.</p>
 </body>
 </html>

--- a/package/mac-resources/welcomeFTDI.html
+++ b/package/mac-resources/welcomeFTDI.html
@@ -10,6 +10,6 @@
 
   <p>The required FTDI USB Serial Driver will also be installed.  The system must be restarted after installation to use it.</p>
 
-  <p>Copyright (c) 2021 Parallax Inc.</p>
+  <p>Copyright (c) 2022 Parallax Inc.</p>
 </body>
 </html>

--- a/package/mac_app_sign_and_package.sh
+++ b/package/mac_app_sign_and_package.sh
@@ -300,17 +300,9 @@ if [ "$?" != "0" ]; then
     exit 1
 fi
 #
-# libswiftshader_libEGL.dylib
+# libvk_swiftshader.dylib
 #
-codesign -s "$APP_IDENTITY" --deep -f -v --options runtime --timestamp --entitlements "${ENTITLEMENTS}" "${DISTRIBUTION}${APP_BUNDLE}${NWJS_FW_LIBRARIES}libswiftshader_libEGL.dylib"
-if [ "$?" != "0" ]; then
-    echo "[Error] Code signing nwjs library failed!" 1>&2
-    exit 1
-fi
-#
-# libswiftshader_libGLESv2.dylib
-#
-codesign -s "$APP_IDENTITY" --deep -f -v --options runtime --timestamp --entitlements "${ENTITLEMENTS}" "${DISTRIBUTION}${APP_BUNDLE}${NWJS_FW_LIBRARIES}libswiftshader_libGLESv2.dylib"
+codesign -s "$APP_IDENTITY" --deep -f -v --options runtime --timestamp --entitlements "${ENTITLEMENTS}" "${DISTRIBUTION}${APP_BUNDLE}${NWJS_FW_LIBRARIES}libvk_swiftshader.dylib"
 if [ "$?" != "0" ]; then
     echo "[Error] Code signing nwjs library failed!" 1>&2
     exit 1

--- a/package/mac_app_sign_and_package_12.1-.sh
+++ b/package/mac_app_sign_and_package_12.1-.sh
@@ -300,9 +300,17 @@ if [ "$?" != "0" ]; then
     exit 1
 fi
 #
-# libvk_swiftshader.dylib
+# libswiftshader_libEGL.dylib
 #
-codesign -s "$APP_IDENTITY" --deep -f -v --options runtime --timestamp --entitlements "${ENTITLEMENTS}" "${DISTRIBUTION}${APP_BUNDLE}${NWJS_FW_LIBRARIES}libvk_swiftshader.dylib"
+codesign -s "$APP_IDENTITY" --deep -f -v --options runtime --timestamp --entitlements "${ENTITLEMENTS}" "${DISTRIBUTION}${APP_BUNDLE}${NWJS_FW_LIBRARIES}libswiftshader_libEGL.dylib"
+if [ "$?" != "0" ]; then
+    echo "[Error] Code signing nwjs library failed!" 1>&2
+    exit 1
+fi
+#
+# libswiftshader_libGLESv2.dylib
+#
+codesign -s "$APP_IDENTITY" --deep -f -v --options runtime --timestamp --entitlements "${ENTITLEMENTS}" "${DISTRIBUTION}${APP_BUNDLE}${NWJS_FW_LIBRARIES}libswiftshader_libGLESv2.dylib"
 if [ "$?" != "0" ]; then
     echo "[Error] Code signing nwjs library failed!" 1>&2
     exit 1
@@ -471,7 +479,6 @@ if [[ -e ${RESOURCES}${DIST_DST} ]]
 then
     echo "Cleaning up temporary files..."   
     rm ${RESOURCES}${DIST_DST}
-    rm ${DISTRIBUTION}${APP_NAME}.pkg
 fi
 
 echo


### PR DESCRIPTION
Version 1.0.7.  Just height (and version) change on actual app.

The installer build includes an updated nw.js wrapper, v0.69.1 (which included Chrome Engine v106) to resolve BP Launcher failure-to-run issue on macOS Ventura v13.0.